### PR TITLE
Add current page highlighting on the pagination 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "yarn build && node ./dist",
-    "dev": "GOOGLE_ANALYTICS_ID= nodemon ./src/index.ts",
+    "dev": "cross-env GOOGLE_ANALYTICS_ID= nodemon ./src/index.ts",
     "build": "rm -rf ./dist/views ./dist/res; tsc --project ./; cp -R ./src/views ./src/res ./dist/",
     "package": "docker build -t miniyotas:latest -f .",
     "package:prod": "docker build -t miniyotas-prod:latest -f Dockerfile.prod .",
@@ -34,6 +34,7 @@
     "@types/express-handlebars": "^5.3.0",
     "@types/google-spreadsheet": "^3.1.2",
     "@types/node": "^15.12.2",
+    "cross-env": "^7.0.3",
     "nodemon": "^2.0.7",
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2"

--- a/src/helpers/handlebars.ts
+++ b/src/helpers/handlebars.ts
@@ -44,3 +44,7 @@ export const repoName = (v1: string): string => {
   const part: Array<string> = v1.split('/');
   return `${part[3]}/${part[4]}`;
 };
+
+export const addClassIfEqual = (v1: number, v2: number, extra: number, v3: string): string => {
+  return v1 === (v2+extra) ? v3 : '';
+};

--- a/src/views/partials/pagination.hbs
+++ b/src/views/partials/pagination.hbs
@@ -17,12 +17,12 @@
         <li class="disabled page-item"><a class="page-link">...</a></li>
     {{/if}}
         {{#each (displayPagesNumber interval current pages)}}
-            {{#if (ifEqual . current 0)}}
+            {{#if (ifEqual . @root.current 0)}}
                 <li class="active page-item"><a class="page-link">{{ . }}</a></li>
             {{else}}
                 {{#if @root.hasParams}}
                     {{#if (contains @root.fullUrl "page")}}
-                        <li class="page-item"><a href="{{{constructUrl @root.fullUrl .}}}" class="page-link">{{ .  }}</a></li>
+                        <li class="page-item {{{addClassIfEqual . @root.current 0 'active'}}}"><a href="{{{constructUrl @root.fullUrl .}}}" class="page-link">{{ . }}</a></li>
                     {{else}}
                         <li class="page-item"><a href="{{@root.fullUrl}}&page={{.}}" class="page-link">{{ . }}</a></li>
                     {{/if}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,6 +381,22 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
@@ -927,6 +943,11 @@ is-yarn-global@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
 
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
 json-bigint@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
@@ -1165,6 +1186,11 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -1331,6 +1357,18 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 signal-exit@^3.0.2:
   version "3.0.3"
@@ -1535,6 +1573,13 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
 
 widest-line@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
# Add current page highlighting on the pagination

This commit is linked to the issues #24 about the current pages highlighting on [miniyotas.osscameroon.com](https://miniyotas.osscameroon.com/)

## Preview

![2024-08-18 15-02-52](https://github.com/user-attachments/assets/be7a2507-13b0-4b56-a9be-b27df0076feb)

## Changes

### [Pagination Component](https://github.com/sikatikenmogne/miniyotas/commit/7c63a611d0bf25263f2ec101b2d9d309d7d56482)
- Added a Handlebars helper function to conditionally add a CSS class for the current page.
- Updated the pagination component to use the new helper function.

### [Environment Variable Handling](https://github.com/sikatikenmogne/miniyotas/commit/8f757d4608f763e4064a90e26a6d4acbde4ce959)
- Installed `cross-env` as a dev dependency.
- Modified the `dev` script in [`package.json`](https://github.com/sikatikenmogne/miniyotas/commit/8f757d4608f763e4064a90e26a6d4acbde4ce959#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8) to use `cross-env` for setting environment variables.

## How to Test

1. **Pagination Component**:
   - Navigate through the pagination component and verify that the current page is highlighted correctly.

2. **Environment Variable Handling**:
   - Run `yarn dev` on both Windows and Unix-based systems to ensure that the environment variable `GOOGLE_ANALYTICS_ID` is set correctly and the application starts without errors.

## Related Issues

- Fixes #24 

## Additional Notes

- Please ensure to run `yarn install` to install the new dev dependency `cross-env`.
- You can also verify that the changes about the [environment variable handling](https://github.com/sikatikenmogne/miniyotas/commit/8f757d4608f763e4064a90e26a6d4acbde4ce959) do not introduce any new issues or regressions or if its does, you can just revert this commit

 