### PR TITLE
Add current page highlighting on the pagination component

### DIFF
--- a/src/helpers/handlebars.ts
+++ b/src/helpers/handlebars.ts
@@ -44,3 +44,7 @@ export const repoName = (v1: string): string => {
   const part: Array<string> = v1.split('/');
   return `${part[3]}/${part[4]}`;
 };
+
+export const addClassIfEqual = (v1: number, v2: number, extra: number, v3: string): string => {
+  return v1 === (v2+extra) ? v3 : '';
+};

--- a/src/views/partials/pagination.hbs
+++ b/src/views/partials/pagination.hbs
@@ -17,12 +17,12 @@
         <li class="disabled page-item"><a class="page-link">...</a></li>
     {{/if}}
         {{#each (displayPagesNumber interval current pages)}}
-            {{#if (ifEqual . current 0)}}
+            {{#if (ifEqual . @root.current 0)}}
                 <li class="active page-item"><a class="page-link">{{ . }}</a></li>
             {{else}}
                 {{#if @root.hasParams}}
                     {{#if (contains @root.fullUrl "page")}}
-                        <li class="page-item"><a href="{{{constructUrl @root.fullUrl .}}}" class="page-link">{{ .  }}</a></li>
+                        <li class="page-item {{{addClassIfEqual . @root.current 0 'active'}}}"><a href="{{{constructUrl @root.fullUrl .}}}" class="page-link">{{ . }}</a></li>
                     {{else}}
                         <li class="page-item"><a href="{{@root.fullUrl}}&page={{.}}" class="page-link">{{ . }}</a></li>
                     {{/if}}


### PR DESCRIPTION
# This pull request related to the issues #24 adds current page highlighting on the pagination component during navigation on [miniyotas.osscameroon.com](https://miniyotas.osscameroon.com/)

## Preview

![2024-08-18 15-02-52](https://github.com/user-attachments/assets/4c8ab5ea-b4dc-45da-8ff0-a2a1cbc72348)

## Changes

- Added a Handlebars helper function for conditional class addition.
- Updated the pagination component to use the new helper function.

## How to Test

1. Navigate through the pagination component and verify that the current page is highlighted correctly.

## Related Issues

- Fixes #24 

## Related Pull Request

- About the commit split request on the conversation #32 

## Additional Notes

- Ensure that the changes do not introduce any new issues or regressions.