### PR TITLE
Add sort by select button

### DIFF
--- a/src/helpers/handlebars.ts
+++ b/src/helpers/handlebars.ts
@@ -10,6 +10,10 @@ export const ifEqual = (a: number, b: number,extra: number): boolean => {
   return a === (b+extra);
 };
 
+export const eq = (a: string, b: string): boolean => {
+  return a === b;
+};
+
 export const ifDifferent = (a: number, b: number): boolean => {
   return a !== b;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,10 +58,19 @@ const paginate = (items: Item[], page: number) => {
 
 const handleContributors = async (req: Request, res: Response) => {
   const query = req.query.query as string | undefined ;
+  const sort = req.query.sort as string | undefined;  // Get the sort option
   const page = req.query.page as string | undefined ;
   let records: Record[] = await getYotas();
 
   records = getRecordsMatchingQuery(query ?? "", records);
+
+  // Apply sorting based on the selected sort option
+  if (sort === "yotas_asc") {
+    records.sort((a, b) => a.yotas - b.yotas);
+  } else if (sort === "yotas_desc") {
+    records.sort((a, b) => b.yotas - a.yotas);
+  }
+
   const { count, items, interval } = paginate(records, parseInt(page ?? "1"));
   const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
 
@@ -70,6 +79,7 @@ const handleContributors = async (req: Request, res: Response) => {
     records: items,
     link: "contributors",
     query,
+    sort,
     currentYear: getCurrentYear(),
     count,
     interval,

--- a/src/shop.ts
+++ b/src/shop.ts
@@ -14,7 +14,7 @@ export interface Item {
 
   //the github_handle field is used to display
   //an image of one of the mentors providing
-  //developper support
+  //developer support
   github_handle?: string;
 };
 

--- a/src/views/partials/contributors.hbs
+++ b/src/views/partials/contributors.hbs
@@ -1,8 +1,13 @@
 <form>
 	<div class="form-group d-flex justify-content-center mt-5 mb-5">
-  	  <div class="form-outline w-75">
+  	  <div class="form-outline w-50">
     	  <input id="search-input" type="text" id="query" name="query" class="form-control" placeholder="search" value="{{query}}"/>
   	  </div>
+	  <select id="sort-select" class="form-select w-25 mx-4 {{#unless sort}}text-muted{{/unless}}" name="sort">
+		  <option value="" disabled selected hidden>sort by...</option>
+           <option class="text-dark" value="yotas_asc" {{#if (eq sort "yotas_asc")}}selected{{/if}}>Yotas (Low to High)</option>
+           <option class="text-dark" value="yotas_desc" {{#if (eq sort "yotas_desc")}}selected{{/if}}>Yotas (High to Low)</option>
+      </select>
   	  <button type="submit" class="btn btn-primary">
   	  	  <i class="fa fa-search" aria-hidden="true"></i>
   	  </button>
@@ -41,3 +46,9 @@
 {{#if  (isLower 0 pages)}}
     {{>pagination}}
 {{/if}}
+
+<script>
+    document.getElementById('sort-select').addEventListener('change', function() {
+        this.form.submit();
+    });
+</script>

--- a/src/yotas.ts
+++ b/src/yotas.ts
@@ -1,5 +1,5 @@
 import YAML from "yaml";
-import { extractHandleFromGitHubUrl } from "./helpers/github";
+import {extractHandleFromGitHubUrl} from "./helpers/github";
 
 import * as fs from "fs";
 
@@ -15,17 +15,16 @@ export type Record = {
 export const getYotas = async (): Promise<Record[]> => {
   const file = fs.readFileSync(yotasFilePath, "utf8");
   const records: Record[] = YAML.parse(file);
-  const yotas = records
-    .map((e: any): Record => {
-      return {
-        github_account: e.github_account,
-        yotas: e.yotas || 0,
-        github_handle: extractHandleFromGitHubUrl(e.github_account),
-        grade: e.grade,
-      };
-    })
-    .sort((a: Record, b: Record): number =>
-      a.github_handle.toLowerCase() > b.github_handle.toLowerCase() ? 1 : -1
-    );
-  return yotas;
+  return records
+      .map((e: any): Record => {
+        return {
+          github_account: e.github_account,
+          yotas: e.yotas || 0,
+          github_handle: extractHandleFromGitHubUrl(e.github_account),
+          grade: e.grade,
+        };
+      })
+      .sort((a: Record, b: Record): number =>
+          a.github_handle.toLowerCase() > b.github_handle.toLowerCase() ? 1 : -1
+      );
 };


### PR DESCRIPTION
 # Add sort by select button

This commit is linked to the issues https://github.com/osscameroon/miniyotas/issues/7 about sorting users by the ascending or descending amount of yotas the possess [miniyotas.osscameroon.com](https://miniyotas.osscameroon.com/)

## Changes

- Added within the `contributors.hbs` file, the select button for sorting users by the ascending or descending amount of yotas
- Updated the handleContributors asynchronous method in the `index.ts` file to add the conditional statements for performing sorting
- Added a script block at the end of the `contributors.hbs` file to handle sorting requests while user changes options from the select button
- Added a new helper **eq** in the `handlebars.ts` file to help with the maintaining the current value of the select button after the page reloads

## How to test

- Navigate to the contributors tab and select an option either **Yotas (Low to High)** or **Yotas (High to Low)** from the select button
- Observe the result on the displayed list of users

## Related Issues

- #7 
