### PR TITLE
fix(proxy): simplify URL construction in pagination links (#36)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const handleContributors = async (req: Request, res: Response) => {
 
   records = getRecordsMatchingQuery(query ?? "", records);
   const { count, items, interval } = paginate(records, parseInt(page ?? "1"));
-  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const fullUrl = req.originalUrl;
 
   res.render("index", {
     fullUrl,
@@ -96,7 +96,7 @@ app.get("/shop", async (req, res) => {
   const query = req.query.query || "";
   const page = req.query.page as string | undefined ;
   const { count, items, interval } = paginate(shopItems,parseInt(page ?? "1") || 1);
-  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const fullUrl = req.originalUrl;
 
   res.render("index", {
     fullUrl,
@@ -113,7 +113,7 @@ app.get("/shop", async (req, res) => {
 });
 
 app.get("/issues", async (req: Request, res: Response) => {
-  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const fullUrl = req.originalUrl;
   const issues: Issue[] = await getIssues();
   const query = req.query.query || "";
   const page = req.query.page as string | undefined ;


### PR DESCRIPTION
## Related Issues
- Fixes #36 

## Changes (initial)
- Added a new helper function called `removeDomain` to handle URL parsing and remove the domain from the given full URL.
- Updated the `constructUrl` helper function to use `removeDomain` for constructing clean URLs.
- Modified the `pagination.hbs` template to use `removeDomain` in the `href` attribute of the page links.

### After review
- Simplifying URL construction by removing @root.fullUrl host part

## Preview
https://github.com/user-attachments/assets/00a01939-5647-48f0-b759-0f4f70cb1e13

### Tested environments
- Github Codespaces
- Windows
- Microsoft DevContainer
