### PR TITLE
refactor: simplify URL construction by removing fullUrl host part

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ const handleContributors = async (req: Request, res: Response) => {
 
   records = getRecordsMatchingQuery(query ?? "", records);
   const { count, items, interval } = paginate(records, parseInt(page ?? "1"));
-  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const fullUrl = req.originalUrl;
 
   res.render("index", {
     fullUrl,
@@ -96,7 +96,7 @@ app.get("/shop", async (req, res) => {
   const query = req.query.query || "";
   const page = req.query.page as string | undefined ;
   const { count, items, interval } = paginate(shopItems,parseInt(page ?? "1") || 1);
-  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const fullUrl = req.originalUrl;
 
   res.render("index", {
     fullUrl,
@@ -113,7 +113,7 @@ app.get("/shop", async (req, res) => {
 });
 
 app.get("/issues", async (req: Request, res: Response) => {
-  const fullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
+  const fullUrl = req.originalUrl;
   const issues: Issue[] = await getIssues();
   const query = req.query.query || "";
   const page = req.query.page as string | undefined ;


### PR DESCRIPTION
# This PR relates to issues #36, fix the pagination URL redirection problem by removing the host part of the [`fullUrl`](https://github.com/osscameroon/miniyotas/blob/7610ee6837aac63d76f4483f48891a8cab528be5/src/index.ts#L66) variable in [`index.ts`](https://github.com/osscameroon/miniyotas/compare/main...sikatikenmogne:miniyotas:fix/pagination-url-redirection#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)

## Changes

- [simplify URL construction by removing fullUrl host part](https://github.com/osscameroon/miniyotas/compare/main...sikatikenmogne:miniyotas:fix/pagination-url-redirection#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80)

## Preview

https://github.com/user-attachments/assets/22dc3099-38a1-454c-9c7d-1aff8cbbf5c7

## How to Test
1. Ensure you have installed dependencies by running yarn install.
2. Start the application with yarn run dev or yarn start.
3. Navigate through the pagination component and confirm that URLs are correctly formatted and redirections work as expected.

### Tested environments
- Github Codespaces
- Windows
- Microsoft DevContainer

## Related Issues
- Fixes #36  

## Related Pull Request
- Related to #37 
